### PR TITLE
Allow empty virtual directory

### DIFF
--- a/manifests/deployment_http.yaml
+++ b/manifests/deployment_http.yaml
@@ -3,10 +3,10 @@ kind: Deployment
 metadata:
   name: wproofreader-app
   labels:
-    helm.sh/chart: wproofreader-1.3.0
+    helm.sh/chart: wproofreader-1.3.1
     app.kubernetes.io/name: wproofreader
     app.kubernetes.io/instance: wproofreader-app
-    app.kubernetes.io/version: "6.2.0.0"
+    app.kubernetes.io/version: "6.11.0.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -34,7 +34,7 @@ spec:
         - name: wproofreader
           securityContext:
             {}
-          image: "webspellchecker/wproofreader:6.2.0.0"
+          image: "webspellchecker/wproofreader:6.11.0.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: container-port

--- a/manifests/deployment_https.yaml
+++ b/manifests/deployment_https.yaml
@@ -3,10 +3,10 @@ kind: Deployment
 metadata:
   name: wproofreader-app
   labels:
-    helm.sh/chart: wproofreader-1.3.0
+    helm.sh/chart: wproofreader-1.3.1
     app.kubernetes.io/name: wproofreader
     app.kubernetes.io/instance: wproofreader-app
-    app.kubernetes.io/version: "6.2.0.0"
+    app.kubernetes.io/version: "6.11.0.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -34,7 +34,7 @@ spec:
         - name: wproofreader
           securityContext:
             {}
-          image: "webspellchecker/wproofreader:6.2.0.0"
+          image: "webspellchecker/wproofreader:6.11.0.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: container-port

--- a/manifests/hpa.yaml
+++ b/manifests/hpa.yaml
@@ -3,10 +3,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: wproofreader-app
   labels:
-    helm.sh/chart: wproofreader-1.3.0
+    helm.sh/chart: wproofreader-1.3.1
     app.kubernetes.io/name: wproofreader
     app.kubernetes.io/instance: wproofreader-app
-    app.kubernetes.io/version: "6.2.0.0"
+    app.kubernetes.io/version: "6.11.0.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:

--- a/manifests/secrets.yaml
+++ b/manifests/secrets.yaml
@@ -3,10 +3,10 @@ kind: Secret
 metadata:
   name: wproofreader-app-lic
   labels:
-    helm.sh/chart: wproofreader-1.3.0
+    helm.sh/chart: wproofreader-1.3.1
     app.kubernetes.io/name: wproofreader
     app.kubernetes.io/instance: wproofreader-app
-    app.kubernetes.io/version: "6.2.0.0"
+    app.kubernetes.io/version: "6.11.0.0"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
@@ -17,10 +17,10 @@ kind: Secret
 metadata:
   name: wproofreader-app-cert
   labels:
-    helm.sh/chart: wproofreader-1.3.0
+    helm.sh/chart: wproofreader-1.3.1
     app.kubernetes.io/name: wproofreader
     app.kubernetes.io/instance: wproofreader-app
-    app.kubernetes.io/version: "6.2.0.0"
+    app.kubernetes.io/version: "6.11.0.0"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:

--- a/manifests/service_http.yaml
+++ b/manifests/service_http.yaml
@@ -3,10 +3,10 @@ kind: Service
 metadata:
   name: wproofreader-app
   labels:
-    helm.sh/chart: wproofreader-1.3.0
+    helm.sh/chart: wproofreader-1.3.1
     app.kubernetes.io/name: wproofreader
     app.kubernetes.io/instance: wproofreader-app
-    app.kubernetes.io/version: "6.2.0.0"
+    app.kubernetes.io/version: "6.11.0.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/manifests/service_https.yaml
+++ b/manifests/service_https.yaml
@@ -3,10 +3,10 @@ kind: Service
 metadata:
   name: wproofreader-app
   labels:
-    helm.sh/chart: wproofreader-1.3.0
+    helm.sh/chart: wproofreader-1.3.1
     app.kubernetes.io/name: wproofreader
     app.kubernetes.io/instance: wproofreader-app
-    app.kubernetes.io/version: "6.2.0.0"
+    app.kubernetes.io/version: "6.11.0.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/manifests/serviceaccount.yaml
+++ b/manifests/serviceaccount.yaml
@@ -3,8 +3,8 @@ kind: ServiceAccount
 metadata:
   name: wproofreader-app
   labels:
-    helm.sh/chart: wproofreader-1.3.0
+    helm.sh/chart: wproofreader-1.3.1
     app.kubernetes.io/name: wproofreader
     app.kubernetes.io/instance: wproofreader-app
-    app.kubernetes.io/version: "6.2.0.0"
+    app.kubernetes.io/version: "6.11.0.0"
     app.kubernetes.io/managed-by: Helm

--- a/manifests/volumes.yaml
+++ b/manifests/volumes.yaml
@@ -3,10 +3,10 @@ kind: PersistentVolume
 metadata:
   name: wproofreader-app-dict
   labels:
-    helm.sh/chart: wproofreader-1.3.0
+    helm.sh/chart: wproofreader-1.3.1
     app.kubernetes.io/name: wproofreader
     app.kubernetes.io/instance: wproofreader-app
-    app.kubernetes.io/version: "6.2.0.0"
+    app.kubernetes.io/version: "6.11.0.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   storageClassName: standard
@@ -29,10 +29,10 @@ kind: PersistentVolumeClaim
 metadata:
   name: wproofreader-app-dict
   labels:
-    helm.sh/chart: wproofreader-1.3.0
+    helm.sh/chart: wproofreader-1.3.1
     app.kubernetes.io/name: wproofreader
     app.kubernetes.io/instance: wproofreader-app
-    app.kubernetes.io/version: "6.2.0.0"
+    app.kubernetes.io/version: "6.11.0.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   storageClassName: standard

--- a/wproofreader/Chart.yaml
+++ b/wproofreader/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for deploying webspellchecker/wproofreader in Kubernet
 
 type: application
 
-version: 1.3.0
+version: 1.3.1
 
-appVersion: "6.2.0.0"
+appVersion: "6.11.0.0"

--- a/wproofreader/templates/NOTES.txt
+++ b/wproofreader/templates/NOTES.txt
@@ -1,6 +1,6 @@
 WProofreader Server has been deployed successfully!
-{{- $baseUrl := printf "http%s://%s.%s.svc:%s/%s/" (.Values.useHTTPS | ternary "s" "") (include "wproofreader.fullname" .)
-    .Release.Namespace (include "wproofreader.servicePort" . | toString) .Values.virtualDir
+{{- $baseUrl := printf "http%s://%s.%s.svc:%s%s/" (.Values.useHTTPS | ternary "s" "") (include "wproofreader.fullname" .)
+    .Release.Namespace (include "wproofreader.servicePort" . | toString) (include "wproofreader.virtualDirBasePath" .)
 }}
 Quick start:
     {{ print $baseUrl }}

--- a/wproofreader/templates/_helpers.tpl
+++ b/wproofreader/templates/_helpers.tpl
@@ -91,6 +91,15 @@ Insert key/cert pair from file.
 {{- end }}
 
 {{/*
+Returns virtualDir as a path prefix: "/wscservice" for "wscservice", or "" for "/" or "".
+Append your path directly: {{ include "wproofreader.virtualDirBasePath" . }}/api?cmd=status
+*/}}
+{{- define "wproofreader.virtualDirBasePath" -}}
+{{- $vd := .Values.virtualDir | trimAll "/" -}}
+{{- if $vd -}}{{- printf "/%s" $vd -}}{{- end -}}
+{{- end }}
+
+{{/*
 Returns default web port as an integer.
 */}}
 {{- define "wproofreader.servicePort" -}}

--- a/wproofreader/templates/deployment.yaml
+++ b/wproofreader/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /{{ .Values.virtualDir }}
+              path: {{ include "wproofreader.virtualDirBasePath" . }}/
               port: container-port
               scheme: {{ if .Values.useHTTPS }}HTTPS{{ else }}HTTP{{ end }}
             {{- with .Values.livenessProbeOptions }}
@@ -52,7 +52,7 @@ spec:
             {{- end }}
           readinessProbe:
             httpGet:
-              path: "/{{ .Values.virtualDir }}/api?cmd=status"
+              path: "{{ include "wproofreader.virtualDirBasePath" . }}/api?cmd=status"
               port: container-port
               scheme: {{ if .Values.useHTTPS }}HTTPS{{ else }}HTTP{{ end }}
             {{- with .Values.readinessProbeOptions }}

--- a/wproofreader/values.yaml
+++ b/wproofreader/values.yaml
@@ -15,8 +15,8 @@ licenseTicketID: ""
 # extra environment variables to pass to the container
 extraEnv: []
 # extraEnv:
-#   - name: WPR_DOMAIN_NAME
-#     value: "wproofreader.domain-name.com"
+#   - name: WPR_JVM_MAX_MEMORY_SIZE_MB
+#     value: "2048"
 
 # directory of the service for web and API requests, e.g. http://localhost/wscservice/api?cmd=ver
 virtualDir: wscservice


### PR DESCRIPTION
## Fix double slashes in paths when `virtualDir` is set to root

Closes #7 

### Issue

Setting `virtualDir: /` or `virtualDir: ""` to deploy WProofreader at the root path caused malformed double-slash paths in probe definitions and the post-install notes URL, because `.Values.virtualDir` was interpolated directly into strings that already contained surrounding
slashes.

### Solution

Added a single reusable helper `wproofreader.virtualDirBasePath` to `_helpers.tpl` that normalizes `virtualDir` into a consistent path prefix:

- `"wscservice"` → `"/wscservice"`
- `"/"` or `""` → `""` (empty string)

This allows all call sites to append their path suffix directly without any per-use-case branching:

```
{{ include "wproofreader.virtualDirBasePath" . }}/api?cmd=status
-> "/wscservice/api?cmd=status"  (default)
-> "/api?cmd=status"             (root)
```

### Changes

| File | Change |
|---|---|
| `templates/_helpers.tpl` | Added `wproofreader.virtualDirBasePath` helper |
| `templates/deployment.yaml` | Liveness and readiness probe paths now use the helper |
| `templates/NOTES.txt` | Base URL construction now uses the helper |
| `values.yaml` | Replaced `WPR_DOMAIN_NAME` example by `WPR_JVM_MAX_MEMORY_SIZE_MB` |

### Notes

- The `WPR_VIRTUAL_DIR` env var passed to the container is intentionally **not** normalized — the container accepts `/` and `""` natively.
- All existing deployments with the default `virtualDir: wscservice` are unaffected.